### PR TITLE
change cookie name

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,7 +6,7 @@ exports.wrapPageElement = ({ element, props }, pluginOptions) => {
   const { CONTENTSTACK_API_KEY } = pluginOptions;
   const { uid, locale, contentType } = props.pageContext;
   const cookieValue = '; ' + document.cookie
-  const cookieParts = cookieValue.split('; optimizely_signed_in=')
+  const cookieParts = cookieValue.split('; optly_berlitz_test=')
   const displayBar = uid && locale && contentType && CONTENTSTACK_API_KEY && cookieParts.length == 2;
   const editEntryUrl = `https://app.contentstack.com/#!/stack/${CONTENTSTACK_API_KEY}/content-type/${contentType}/${locale}/entry/${uid}/edit`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-admin-bar-contentstack",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "gatsby-browser.js",
   "description": "",
   "homepage": "https://github.com/berlitz-global/gatsby-plugin-admin-bar-contentstack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-admin-bar-contentstack",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "gatsby-browser.js",
   "description": "",
   "homepage": "https://github.com/berlitz-global/gatsby-plugin-admin-bar-contentstack",


### PR DESCRIPTION
the old cookie name was in optimizely.com domain, it is not accessable from berlitz.com. So I have changed the cookie name to be optly_berlitz_test